### PR TITLE
Emit warning when not able to acquire spin lock after 10k attempts

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 {{$NEXT}}
+  -  Additional runtime checks
+  -  Emit warning when failed to acquire spin lock after 10000 attempts
+     (befere that change it entered into endless loop aka live-lock)
 
 0.03      2017-02-21 02:13:25+00:00 UTC
   -  Switch to dzil

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,7 +31,8 @@ my %WriteMakefileArgs = (
     "IPC::Open3" => 0,
     "Test::CheckDeps" => "0.010",
     "Test::Fatal" => 0,
-    "Test::More" => "0.94"
+    "Test::More" => "0.94",
+    "Test::Warnings" => 0
   },
   "VERSION" => "0.03",
   "test" => {
@@ -53,6 +54,7 @@ my %FallbackPrereqs = (
   "Test::CheckDeps" => "0.010",
   "Test::Fatal" => 0,
   "Test::More" => "0.94",
+  "Test::Warnings" => 0,
   "namespace::clean" => 0
 );
 

--- a/cpanfile
+++ b/cpanfile
@@ -13,4 +13,5 @@ on configure => sub {
 on test => sub {
     requires 'Test::Fatal';
     requires 'Test::More';
+    requires 'Test::Warnings';
 };

--- a/lib/IPC/LeaderBoard.pm
+++ b/lib/IPC/LeaderBoard.pm
@@ -375,7 +375,8 @@ sub update {
     # updating private values
     if (%private_values) {
         my $idx_delta = $self->_generation_idx + 1;
-        while (my ($private_idx, $value) = each %private_values) {
+        for my $private_idx (keys %private_values) {
+            my $value = $private_values{$private_idx};
             if (($private_idx >= $self->slot_private_size) || ($private_idx < 0)) {
                 die("wrong private index");
             }

--- a/lib/IPC/LeaderBoard.pm
+++ b/lib/IPC/LeaderBoard.pm
@@ -12,6 +12,8 @@ use namespace::clean;
 
 our $VERSION = '0.03';
 
+my $max_lock_attempts = $ENV{IPC_LEADERBOARD_MAX_SPINLOCK_ATTEMPTS} // 10000;
+
 =head1 NAME
 
 IPC::LeaderBoard - fast per-symbol online get/update information
@@ -339,8 +341,16 @@ sub update {
     # updating shared values
     if ($values) {
         die("values size mismatch slot size") if @$values != $self->slot_shared_size;
+
         # obtain spin-lock
-        $sb->decr($idx, 0) until $sb->incr($idx, 0) == 1;
+        my $attempts = 0;
+        while($sb->incr($idx, 0) != 1) {
+            $sb->decr($idx, 0);
+            if (++$attempts > $max_lock_attempts) {
+                warn("failed to acquire spin lock for row $idx after $attempts attempts");
+                return 0;
+            }
+        }
         # release the lock at the end of the scope
         scope_guard { $sb->decr($idx, 0) };
 
@@ -366,7 +376,9 @@ sub update {
     if (%private_values) {
         my $idx_delta = $self->_generation_idx + 1;
         while (my ($private_idx, $value) = each %private_values) {
-            die("wrong private index") if $private_idx >= $self->slot_private_size;
+            if (($private_idx >= $self->slot_private_size) || ($private_idx < 0)) {
+                die("wrong private index");
+            }
             $sb->set($idx, $private_idx + $idx_delta, $value);
         }
     }

--- a/t/leaderboard.t
+++ b/t/leaderboard.t
@@ -3,6 +3,7 @@ use warnings;
 
 use Test::Fatal;
 use Test::More;
+use Test::Warnings qw/:all/;
 use Fcntl ':flock'; # import LOCK_* constants
 use Path::Tiny;
 
@@ -107,6 +108,71 @@ subtest "usage" => sub {
   $slave_1->read_slot(0);
   ok !$slave_1->update(0, 0 => 7), "successfull private update (no succes of shared data update, as we don't provide values for it)";
   is_deeply [$slave_1->read_slot(0)], [[11, 12, 13, 14], [7, 99]], "assure that we get the last values we have written";
+};
+
+subtest "edge-cases" => sub {
+    $locked = 0;
+    my $master = $create->();
+    my ($slave_1, $slave_2) = map { $attach->() } (0 .. 1);
+    like(
+        exception { $slave_1->read_slot(2) },
+        qr/wrong index/,
+        "the code died in attempt to read row out of scope",
+    );
+
+    like(
+        exception { $slave_1->read_slot(-1) },
+        qr/wrong index/,
+        "the code died in attempt to read row out of scope",
+    );
+
+    like(
+        exception { $slave_1->update(2, [1, 2, 3, 4]) },
+        qr/wrong index/,
+        "the code died in attempt to write row out of scope",
+    );
+
+    like(
+        exception { $slave_1->update(-1, [1, 2, 3, 4]) },
+        qr/wrong index/,
+        "the code died in attempt to write row out of scope",
+    );
+
+    $slave_1->read_slot(0);
+    like(
+        exception { $slave_1->update(0, 2 => 5) },
+        qr/wrong private index/,
+        "the code died in attempt to write private datea out of row",
+    );
+
+    like(
+        exception { $slave_1->update(0, -1 => 5) },
+        qr/wrong private index/,
+        "the code died in attempt to write private datea out of row",
+    );
+
+    like(
+        exception { $slave_1->update(0, [1, 2, 3]) },
+        qr/values size mismatch slot size/,
+        "the code died in attempt to update shared datas with wrong vector size",
+    );
+
+    like(
+        exception { $slave_1->update(0, [1, 2, 3, 4, 5]) },
+        qr/values size mismatch slot size/,
+        "the code died in attempt to update shared datas with wrong vector size",
+    );
+
+    # manually set spin lock to some value(5) (should be zero, by default)
+    $slave_1->_score_board->set(0, 0, 5);
+    my $operation_result;
+    like(
+        warning { $operation_result = $slave_1->update(0, [1, 2, 3, 4]) },
+        qr/failed to acquire spin lock/,
+        "warning emitted when spinlock wasn't acquired"
+    );
+    ok !$operation_result;
+
 
 };
 


### PR DESCRIPTION
Previously it entered into endless loop (spinlock). Warning and
exiting with failure from `update` will prevent that.

Add checks to prevent accidently to set spinlock by indices manilupations.